### PR TITLE
fix: pypi trusted publishing setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,8 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/polyglot-ffi
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
     - name: Download build artifacts
@@ -145,9 +147,7 @@ jobs:
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        skip-existing: true
+      # Using Trusted Publishing (OIDC) - no password/token needed!
 
   publish-docs:
     name: Publish documentation


### PR DESCRIPTION
Update release workflow for PyPI Trusted Publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security for the package release process by updating the authentication method for publishing, ensuring more secure and reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->