### PR TITLE
docs: add documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Stop writing FFI boilerplate. Start building amazing things.
 
+**[Full Documentation](https://chizy7.github.io/polyglot-ffi/)** | [Quickstart](https://chizy7.github.io/polyglot-ffi/quickstart/) | [API Reference](https://chizy7.github.io/polyglot-ffi/api/) | [Type Mapping](https://chizy7.github.io/polyglot-ffi/type-mapping/)
+
 ## What is Polyglot FFI?
 
 Polyglot FFI automatically generates complete Foreign Function Interface (FFI) bindings between programming languages. Write your OCaml interface once, and get type-safe, memory-safe bindings for Python (and soon Rust, Go, etc.) instantly.


### PR DESCRIPTION
## Summary
  - Add prominent documentation links section near the top of README
  - Include links to main docs, quickstart, API reference, and type mapping
  - Improve documentation discoverability for new users
  - Codecov configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Full Documentation banner to README with links for improved resource discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->