### PR TITLE
fix: revert site_url to GitHub Pages URL to fix docs deployment

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Polyglot FFI Documentation
 site_description: Automatic FFI bindings generator for polyglot projects
 site_author: Polyglot FFI Contributors
-site_url: https://polyglotffi.com/
+site_url: https://chizy7.github.io/polyglot-ffi/
 
 repo_name: chizy7/polyglot-ffi
 repo_url: https://github.com/chizy7/polyglot-ffi


### PR DESCRIPTION
Quick docs url deploy fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site hosting location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->