### PR TITLE
docs: add OCaml setup instructions to Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,17 @@ polyglot-ffi --version
 pytest tests/ -v
 ```
 
+## Optional Dependencies
+
+If you want to test the generated OCaml bindings (for integration tests):
+
+```bash
+# Install OCaml and required libraries
+opam install dune ctypes ctypes-foreign
+```
+
+**Note:** This is only needed for running integration tests that compile generated bindings. Unit tests don't require OCaml.
+
 ## Development Workflow
 
 1. **Create a branch** for your feature/fix


### PR DESCRIPTION
 ## Summary
  - Adds "Optional Dependencies" section to CONTRIBUTING.md
  - Clarifies that OCaml toolchain is only needed for integration tests
  - Helps new contributors understand the full development setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Optional Dependencies section with instructions for installing OCaml-related tooling for testing generated OCaml bindings.
  * Clarified that standard unit tests do not require OCaml tooling installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->