### PR TITLE
ci: wire ruff gating, promote mypy gating, drop flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,21 +64,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
-        pip install flake8 mypy
 
     - name: Check code formatting with black
       run: |
         black --check src/ tests/
 
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        # Stop the build if there are Python syntax errors or undefined names
-        flake8 src/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        # Exit-zero treats all errors as warnings
-        flake8 src/ --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+        ruff check src/ tests/
 
     - name: Type check with mypy
-      continue-on-error: true
       run: |
         mypy src/ --ignore-missing-imports
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,16 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+# TypeError_ intentionally trails with underscore to avoid shadowing the builtin
+"src/polyglot_ffi/utils/errors.py" = ["N801", "N818"]
+# Generator templates emit C/dune/Makefile source; line breaks would corrupt output
+"src/polyglot_ffi/generators/c_stubs_gen.py" = ["E501"]
+"src/polyglot_ffi/generators/dune_gen.py" = ["E501"]
+"src/polyglot_ffi/commands/init.py" = ["E501"]
+# Test names mirror the capitalized input strings they're testing
+"tests/unit/test_errors.py" = ["N802"]
+
 [tool.mypy]
 python_version = "3.10"
 warn_return_any = true

--- a/src/polyglot_ffi/cli/main.py
+++ b/src/polyglot_ffi/cli/main.py
@@ -88,7 +88,7 @@ def init(
         ) as progress:
             task = progress.add_task("Initializing project...", total=None)
 
-            result = init_project(
+            init_project(
                 name=project_name, target_langs=list(lang), template=template, verbose=verbose
             )
 
@@ -178,7 +178,7 @@ def generate(
                         "  • Set 'enabled = true' for at least one target in polyglot.toml"
                     )
                     console.print(
-                        "  • Or use --target flag to specify targets: polyglot-ffi generate --target python"
+                        "  • Or use --target flag to specify targets: polyglot-ffi generate --target python"  # noqa: E501
                     )
                     console.print("  • Run 'polyglot-ffi check' to validate your configuration")
                     console.print()

--- a/src/polyglot_ffi/commands/check.py
+++ b/src/polyglot_ffi/commands/check.py
@@ -120,7 +120,7 @@ def display_check_results(results: dict[str, Any]) -> None:
                 f"\n[bold]Project:[/bold] {config.project.name} v{config.project.version}"
             )
             console.print(
-                f"[bold]Source:[/bold] {config.source.language} ({len(config.source.files)} file(s))"
+                f"[bold]Source:[/bold] {config.source.language} ({len(config.source.files)} file(s))"  # noqa: E501
             )
 
             # Targets table

--- a/src/polyglot_ffi/commands/generate.py
+++ b/src/polyglot_ffi/commands/generate.py
@@ -118,7 +118,7 @@ def generate_bindings(
         print(f"✓ Found {len(ir_module.functions)} function(s)")
         for func in ir_module.functions:
             print(
-                f"  - {func.name}: {' -> '.join(str(p.type) for p in func.params)} -> {func.return_type}"
+                f"  - {func.name}: {' -> '.join(str(p.type) for p in func.params)} -> {func.return_type}"  # noqa: E501
             )
 
     # Create output directory
@@ -131,7 +131,7 @@ def generate_bindings(
         existing_files = list(output_path.glob("*"))
         if existing_files:
             print(
-                f"Warning: Output directory '{output_path}' already exists with {len(existing_files)} file(s)."
+                f"Warning: Output directory '{output_path}' already exists with {len(existing_files)} file(s)."  # noqa: E501
             )
             print("  Existing files may be overwritten. Use --force to suppress this warning.")
 

--- a/src/polyglot_ffi/core/config.py
+++ b/src/polyglot_ffi/core/config.py
@@ -182,7 +182,7 @@ def load_config(config_path: Path) -> PolyglotConfig:
         if "Field required" in error_msg or "missing" in error_msg.lower():
             suggestions.append("Add the required section to your polyglot.toml")
             suggestions.append(
-                "Required sections: 'project' (with name field), 'source' (with language), 'targets' (array)"
+                "Required sections: 'project' (with name field), 'source' (with language), 'targets' (array)"  # noqa: E501
             )
             suggestions.append("Example: See the template created by 'polyglot-ffi init'")
         # Check if it's an unsupported language error

--- a/src/polyglot_ffi/ir/types.py
+++ b/src/polyglot_ffi/ir/types.py
@@ -164,7 +164,7 @@ class IRModule:
     doc: str = ""
 
     def __str__(self) -> str:
-        return f"Module {self.name} ({len(self.functions)} functions, {len(self.type_definitions)} types)"
+        return f"Module {self.name} ({len(self.functions)} functions, {len(self.type_definitions)} types)"  # noqa: E501
 
     def get_function(self, name: str) -> IRFunction | None:
         """Get function by name."""

--- a/src/polyglot_ffi/parsers/ocaml.py
+++ b/src/polyglot_ffi/parsers/ocaml.py
@@ -162,9 +162,8 @@ class OCamlParser:
                 # Variant type
                 return self._parse_variant_type(type_name, type_body, start_line), lines_consumed
             else:
-                # Type alias - treat as custom named type
-                aliased_type = self._parse_type(type_body, start_line)
-                # For now, we'll skip pure type aliases as they don't need special handling
+                # Type alias - parse for validation, but skip (no special handling needed)
+                self._parse_type(type_body, start_line)
                 return None, lines_consumed
 
         except ParseError as e:

--- a/src/polyglot_ffi/utils/naming.py
+++ b/src/polyglot_ffi/utils/naming.py
@@ -103,7 +103,7 @@ def sanitize_module_name(name: str) -> str:
     # Check if it starts with an underscore (also invalid in OCaml modules)
     if sanitized and sanitized[0] == "_":
         raise ValueError(
-            f"Module name '{name}' is invalid: OCaml module names cannot start with an underscore.\n"
+            f"Module name '{name}' is invalid: OCaml module names cannot start with an underscore.\n"  # noqa: E501
             f"  Suggestions:\n"
             f"  • Rename the file to start with a letter (e.g., 'module{name}')\n"
             f"  • Remove leading underscores"

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -317,7 +317,6 @@ enabled = true
     def test_clean_files_dry_run(self, generated_files_dir, capsys):
         """Test cleaning files in dry-run mode."""
         files_to_clean = find_generated_files([generated_files_dir], all_files=False)
-        initial_count = len(files_to_clean)
 
         count = clean_files(files_to_clean, dry_run=True)
 
@@ -388,7 +387,7 @@ enabled = true
         # Create some files
         (generated_files_dir / "test_stubs.c").write_text("test")
 
-        count = clean_project(all_files=False, dry_run=True)
+        clean_project(all_files=False, dry_run=True)
 
         captured = capsys.readouterr()
         assert "Dry run" in captured.out
@@ -718,8 +717,8 @@ files = ["test.mli"]
         # Config loads but validator should catch empty targets
         try:
             config = load_config(no_targets)
-            # If it loads, validate should warn about it
-            warnings = validate_config(config)
+            # If it loads, validate should run without error
+            validate_config(config)
             # Should have no targets
             assert len(config.targets) == 0 or all(not t.enabled for t in config.targets)
         except ConfigurationError:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -268,18 +268,17 @@ class TestPythonVersionCompatibility:
     """Test Python version compatibility for tomli import."""
 
     @pytest.mark.skipif(
-        sys.version_info < (3, 9),
-        reason="Pydantic reload incompatible with Python 3.8 (requires GenericAlias)",
+        sys.version_info >= (3, 11),
+        reason="tomli is only installed on Python < 3.11; on 3.11+ tomllib comes from stdlib",
     )
     def test_tomli_import_on_old_python(self, monkeypatch):
-        """Test tomli import path for Python < 3.11."""
+        """Verify the tomli fallback resolves on Python < 3.11."""
         import sys
 
         import polyglot_ffi.core.config as config_module
 
-        # Save original values
+        # Save original version (tomllib is restored via importlib.reload below)
         original_version = sys.version_info
-        original_tomllib = config_module.tomllib
 
         try:
             # Simulate Python 3.10
@@ -291,9 +290,9 @@ class TestPythonVersionCompatibility:
             importlib.reload(config_module)
 
             # tomllib should be imported from tomli on Python < 3.11
-            # verify the import succeeded (tomllib is available)
-            # assert config_module.tomllib is not None, "tomllib should be available via tomli fallback"
-            assert config_module.tomllib is not None or config_module.tomllib is None
+            assert (
+                config_module.tomllib is not None
+            ), "tomllib should be available via tomli fallback"
 
         finally:
             # Restore original values

--- a/tests/unit/test_memory_management.py
+++ b/tests/unit/test_memory_management.py
@@ -312,14 +312,6 @@ class TestOptionTypeEdgeCases:
 
         # Should use 'is None' check, not falsy check
         # This ensures Some(False) is not treated as None
-        lines = wrapper.split("\n")
-        found_is_none = False
-        for line in lines:
-            if "bool" in line and "if result is None:" in line:
-                found_is_none = True
-                break
-
-        # The wrapper should handle bool options with proper None check
         assert "if result is None:" in wrapper
 
     def test_option_int_zero_is_not_none(self):


### PR DESCRIPTION
## Summary

* Drop flake8 from CI (its only effective check was Python syntax, which `import` already catches)
* Add `ruff check` as a gating CI step (`ruff` was already in dev deps but never ran)
* Remove `continue-on-error: true` from mypy — type errors now fail CI
* Add `[tool.ruff.lint.per-file-ignores]` documenting four intentional patterns (`TypeError_` naming, generator-template long lines, test-name capitalization)
* Fix 7 dead `F841` assignments (none were real bugs; mostly tests with unused locals and one `init_project` call missing its discarded return)
* Add `# noqa: E501` on 8 user-facing strings where wrapping hurts readability